### PR TITLE
Add support for custom extra attributes configuration

### DIFF
--- a/example/lib/custom_card_storybook.dart
+++ b/example/lib/custom_card_storybook.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:storybook_ds/src/utils/typedef_storybook.dart';
 import 'package:storybook_ds/storybook_ds.dart';
 
 import 'custom_card.dart';
@@ -327,4 +328,7 @@ class _CustomCardStorybookState extends Storybook<CustomCardStorybook> {
 
   @override
   String title = 'Custom Card';
+
+  @override
+  OnBuildExtraAttributesConfigCustom? get extraAttributesConfigCustom => null;
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -328,7 +328,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0+17"
+    version: "1.2.1+19"
   stream_channel:
     dependency: transitive
     description:

--- a/lib/src/utils/typedef_storybook.dart
+++ b/lib/src/utils/typedef_storybook.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+typedef OnBuildExtraAttributesConfigCustom = Widget Function(
+  BuildContext context,
+);

--- a/lib/src/widgets/content_widget.dart
+++ b/lib/src/widgets/content_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:storybook_ds/src/models/multiple_theme_settings.dart';
+import 'package:storybook_ds/src/utils/typedef_storybook.dart';
 import 'package:storybook_ds/src/widgets/attributes_variant_widget.dart';
 
 import '../models/dto/attribute_dto.dart';
@@ -25,6 +26,7 @@ class ContentWidget extends StatelessWidget {
 
   final Function(String? constructor) onSelectedConstructor;
   final String Function() updatePreviewCode;
+  final OnBuildExtraAttributesConfigCustom? extraAttributesConfigCustom;
 
   const ContentWidget({
     super.key,
@@ -38,6 +40,7 @@ class ContentWidget extends StatelessWidget {
     this.constructor,
     this.multipleThemeSettings,
     this.onUpdateTheme,
+    this.extraAttributesConfigCustom,
   });
 
   @override
@@ -56,6 +59,11 @@ class ContentWidget extends StatelessWidget {
             _buildTitle(context),
             _buildDescription(context),
             _buildBuilders(context, attributes),
+            if (extraAttributesConfigCustom != null)
+              ...[
+                const SizedBox(height: 12),
+                extraAttributesConfigCustom!(context)
+              ],
             _buildAttributesTheme(multipleThemeSettings),
             _buildAttributesVariant(attributes),
             // _buildPreviewCode(context),
@@ -163,6 +171,7 @@ class _BuildersState extends State<Builders> {
     _constructor = widget.initConstructor;
     super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
     return Padding(

--- a/lib/src/widgets/storybook/storybook_component/storybook_component.dart
+++ b/lib/src/widgets/storybook/storybook_component/storybook_component.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:storybook_ds/src/utils/typedef_storybook.dart';
 import 'package:storybook_ds/storybook_ds.dart';
 
 import 'storybook_component_state.dart';
@@ -55,6 +56,7 @@ class StoryBookComponent extends StatefulWidget {
     this.controller,
     this.backgroundColor,
     this.onUpdateTheme,
+    this.extraAttributesConfigCustom,
   });
 
   final Widget child;
@@ -68,6 +70,7 @@ class StoryBookComponent extends StatefulWidget {
   final void Function(
     MultipleThemeSettings multipleThemeSettings,
   )? onUpdateTheme;
+  final OnBuildExtraAttributesConfigCustom? extraAttributesConfigCustom;
 
   @override
   State<StoryBookComponent> createState() => _StoryBookComponenState();
@@ -91,6 +94,7 @@ class _StoryBookComponenState extends State<StoryBookComponent> {
         multipleThemeSettings: widget.multipleThemeSettings,
         backgroundColor: widget.backgroundColor,
         onUpdateTheme: widget.onUpdateTheme,
+        extraAttributesConfigCustom: widget.extraAttributesConfigCustom,
         child: widget.child,
       );
 }

--- a/lib/src/widgets/storybook/storybook_component/storybook_component_state.dart
+++ b/lib/src/widgets/storybook/storybook_component/storybook_component_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:storybook_ds/src/utils/typedef_storybook.dart';
 import 'package:storybook_ds/storybook_ds.dart';
 
 class StoryBookComponentState extends StatefulWidget {
@@ -13,6 +14,7 @@ class StoryBookComponentState extends StatefulWidget {
     this.multipleThemeSettings,
     this.backgroundColor,
     this.onUpdateTheme,
+    this.extraAttributesConfigCustom,
   });
   final Widget child;
   final String title;
@@ -25,6 +27,7 @@ class StoryBookComponentState extends StatefulWidget {
   final void Function(
     MultipleThemeSettings multipleThemeSettings,
   )? onUpdateTheme;
+  final OnBuildExtraAttributesConfigCustom? extraAttributesConfigCustom;
 
   @override
   Storybook<StoryBookComponentState> createState() =>
@@ -38,6 +41,7 @@ class StoryBookComponentState extends StatefulWidget {
         controller: controller,
         multipleThemeSettings: multipleThemeSettings,
         backgroundColor: backgroundColor,
+        extraAttributesConfigCustom: extraAttributesConfigCustom,
       );
 }
 
@@ -55,6 +59,9 @@ class _StoryBookComponentStateState extends Storybook<StoryBookComponentState> {
   @override
   final MultipleThemeSettings? multipleThemeSettings;
 
+  @override
+  OnBuildExtraAttributesConfigCustom? extraAttributesConfigCustom;
+
   final Color? backgroundColor;
   final StoryBookComponentController? controller;
 
@@ -67,6 +74,7 @@ class _StoryBookComponentStateState extends Storybook<StoryBookComponentState> {
     required this.controller,
     required this.multipleThemeSettings,
     required this.backgroundColor,
+    this.extraAttributesConfigCustom,
   });
 
   @override

--- a/lib/src/widgets/storybook/storybook_mobile.dart
+++ b/lib/src/widgets/storybook/storybook_mobile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:storybook_ds/src/utils/typedef_storybook.dart';
 import 'package:storybook_ds/storybook_ds.dart';
 
 import '../../utils/utils.dart';
@@ -26,6 +27,8 @@ abstract class Storybook<T extends StatefulWidget> extends State<T> {
   /// Constrói o widget do componente.
   Widget buildComponentWidget(BuildContext context);
 
+  OnBuildExtraAttributesConfigCustom? get extraAttributesConfigCustom;
+
   getWhereAttribut(String name) {
     final attribute = attributes.where((e) => e.name == name).first;
     return attribute.selectedValue?.value;
@@ -49,16 +52,20 @@ abstract class Storybook<T extends StatefulWidget> extends State<T> {
           backgroundColor: Colors.white,
           elevation: 0,
           automaticallyImplyLeading: false,
-          bottom: const TabBar(
+          bottom: TabBar(
             labelColor: Colors.black,
             tabs: <Widget>[
-              Tab(
+              if (extraAttributesConfigCustom != null)
+                const Tab(
+                  text: 'Atributos Extra',
+                ),
+              const Tab(
                 text: 'Atributos',
               ),
-              Tab(
+              const Tab(
                 text: 'Componente',
               ),
-              Tab(
+              const Tab(
                 text: 'Código',
               ),
             ],
@@ -66,6 +73,10 @@ abstract class Storybook<T extends StatefulWidget> extends State<T> {
         ),
         body: TabBarView(
           children: <Widget>[
+            if (extraAttributesConfigCustom != null)
+              Center(
+                child: extraAttributesConfigCustom!(context),
+              ),
             Center(
               child: _buildContent(),
             ),

--- a/lib/src/widgets/storybook/storybook_web.dart
+++ b/lib/src/widgets/storybook/storybook_web.dart
@@ -6,6 +6,7 @@ import 'package:storybook_ds/src/device_preview/views/tool_panel/sections/device
 import 'package:storybook_ds/src/device_preview/views/tool_panel/sections/section.dart';
 import 'package:storybook_ds/src/device_preview/views/tool_panel/sections/settings.dart';
 import 'package:storybook_ds/src/models/multiple_theme_settings.dart';
+import 'package:storybook_ds/src/utils/typedef_storybook.dart';
 
 import '../../models/dto/attribute_dto.dart';
 import '../../utils/utils.dart';
@@ -33,6 +34,8 @@ abstract class Storybook<T extends StatefulWidget> extends State<T> {
   /// Constrói o widget do componente.
   Widget buildComponentWidget(BuildContext context);
 
+  OnBuildExtraAttributesConfigCustom? get extraAttributesConfigCustom;
+
   @protected
   @mustCallSuper
   void onUpdateAttributes(List<AttributeDto> attributes) {
@@ -58,7 +61,6 @@ abstract class Storybook<T extends StatefulWidget> extends State<T> {
               mainAxisSize: MainAxisSize.max,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-              
                 Expanded(
                   child: SingleChildScrollView(
                     child: _buildDevice(context, height),
@@ -94,6 +96,7 @@ abstract class Storybook<T extends StatefulWidget> extends State<T> {
         });
       },
       updatePreviewCode: updatePreviewCode,
+      extraAttributesConfigCustom: this.extraAttributesConfigCustom,
     );
   }
 


### PR DESCRIPTION
Introduces the `OnBuildExtraAttributesConfigCustom` typedef and integrates it across storybook components. This enables optional rendering of customizable extra attributes both in the UI and logic, enhancing flexibility for storybook widget configurations.